### PR TITLE
return on 'send' __call

### DIFF
--- a/classes/mailer.php
+++ b/classes/mailer.php
@@ -148,7 +148,7 @@ class Mailer {
 				$this->setup_message($method);
 				
 				//send the message
-				$this->send();
+				return $this->send();
 			}
 			else
 			{


### PR DESCRIPTION
hi there! I think it's better returning true or false when sending e-mail for control purposes, so I added a return method to __call function (line 151) when sending an email to see if it was successful or not instead of always returning null and assuming it was sent. 

what do you think?
